### PR TITLE
Check out full history

### DIFF
--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 64
+          fetch-depth: 0
       - name: Run checks
         run: |
           bash .github/scripts/patches.sh


### PR DESCRIPTION
Some CI tests require the full git history to function properly.