### PR TITLE
Never log to stdout

### DIFF
--- a/.github/scripts/patches/build_rv32_defconfig.sh
+++ b/.github/scripts/patches/build_rv32_defconfig.sh
@@ -8,14 +8,14 @@ tmpfile=$(mktemp)
 rc=0
 
 tuxmake --wrapper ccache --target-arch riscv --directory . \
-	--environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
-	--environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
-	-o $tmpdir --toolchain llvm -z none -k rv32_defconfig \
-	CROSS_COMPILE=riscv64-linux- \
-	> $tmpfile || rc=1
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir --toolchain llvm -z none -k rv32_defconfig \
+        CROSS_COMPILE=riscv64-linux- \
+        >$tmpfile 2>/dev/null || rc=1
 
 if [ $rc -ne 0 ]; then
-	grep "\(warning\|error\):" $tmpfile >&2
+        grep "\(warning\|error\):" $tmpfile
 fi
 
 rm -rf $tmpdir $tmpfile

--- a/.github/scripts/patches/build_rv64_clang_allmodconfig.sh
+++ b/.github/scripts/patches/build_rv64_clang_allmodconfig.sh
@@ -24,19 +24,18 @@ git log -1 --pretty='%h ("%s")' HEAD~
 echo "Building the whole tree with the patch"
 
 tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
-	--environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
-	--environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
-	-o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
-	-K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y -K CONFIG_SAMPLES=n W=1 \
-	CROSS_COMPILE=riscv64-linux- \
-	config default \
-	> $tmpfile_e || rc=1
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y -K CONFIG_SAMPLES=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_e 2>/dev/null || rc=1
 
-if [ $rc -eq 1 ]
-then
-	grep "\(error\):" $tmpfile_e >&2
-	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
-	exit $rc
+if [ $rc -eq 1 ]; then
+        grep "\(error\):" $tmpfile_e
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
+        exit $rc
 fi
 
 current=$(grep -c "\(warning\|error\):" $tmpfile_n)
@@ -46,13 +45,13 @@ git checkout -q HEAD~
 echo "Building the tree before the patch"
 
 tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
-	--environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
-	--environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
-	-o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
-	-K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
-	CROSS_COMPILE=riscv64-linux- \
-	config default \
-	> $tmpfile_o
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_o 2>/dev/null
 
 incumbent=$(grep -c "\(warning\|error\):" $tmpfile_o)
 
@@ -61,48 +60,47 @@ git checkout -q $HEAD
 echo "Building the tree with the patch"
 
 tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
-	--environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
-	--environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
-	-o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
-	-K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
-	CROSS_COMPILE=riscv64-linux- \
-	config default \
-	> $tmpfile_n || rc=1
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_n 2>/dev/null || rc=1
 
-if [ $rc -eq 1 ]
-then
-	grep "\(warning\|error\):" $tmpfile_n >&2
-	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
-	exit $rc
+if [ $rc -eq 1 ]; then
+        grep "\(warning\|error\):" $tmpfile_n
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+        exit $rc
 fi
 
 current=$(grep -c "\(warning\|error\):" $tmpfile_n)
 
 if [ $current -gt $incumbent ]; then
-  echo "New errors added:" 1>&2
+        echo "New errors added:"
 
-  tmpfile_errors_before=$(mktemp)
-  tmpfile_errors_now=$(mktemp)
-  grep "\(warning\|error\):" $tmpfile_o | sort | uniq -c > $tmpfile_errors_before
-  grep "\(warning\|error\):" $tmpfile_n | sort | uniq -c > $tmpfile_errors_now
+        tmpfile_errors_before=$(mktemp)
+        tmpfile_errors_now=$(mktemp)
+        grep "\(warning\|error\):" $tmpfile_o | sort | uniq -c > $tmpfile_errors_before
+        grep "\(warning\|error\):" $tmpfile_n | sort | uniq -c > $tmpfile_errors_now
 
-  diff -U 0 $tmpfile_errors_before $tmpfile_errors_now 1>&2
+        diff -U 0 $tmpfile_errors_before $tmpfile_errors_now
 
-  rm $tmpfile_errors_before $tmpfile_errors_now
+        rm $tmpfile_errors_before $tmpfile_errors_now
 
-  echo "Per-file breakdown" 1>&2
-  tmpfile_fo=$(mktemp)
-  tmpfile_fn=$(mktemp)
+        echo "Per-file breakdown"
+        tmpfile_fo=$(mktemp)
+        tmpfile_fn=$(mktemp)
 
-  grep "\(warning\|error\):" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fo
-  grep "\(warning\|error\):" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fn
+        grep "\(warning\|error\):" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fo
+        grep "\(warning\|error\):" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fn
 
-  diff -U 0 $tmpfile_fo $tmpfile_fn 1>&2
-  rm $tmpfile_fo $tmpfile_fn
-  echo "pre: $incumbent post: $current"
-  rc=1
+        diff -U 0 $tmpfile_fo $tmpfile_fn
+        rm $tmpfile_fo $tmpfile_fn
+        echo "pre: $incumbent post: $current"
+        rc=1
 fi
 
 rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e

--- a/.github/scripts/patches/build_rv64_gcc_allmodconfig.sh
+++ b/.github/scripts/patches/build_rv64_gcc_allmodconfig.sh
@@ -24,19 +24,18 @@ git log -1 --pretty='%h ("%s")' HEAD~
 echo "Building the whole tree with the patch"
 
 tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
-	--environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
-	--environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
-	-o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
-	-K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
-	CROSS_COMPILE=riscv64-linux- \
-	config default \
-	> $tmpfile_e || rc=1
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_e 2>/dev/null || rc=1
 
-if [ $rc -eq 1 ]
-then
-	grep "\(error\):" $tmpfile_e >&2
-	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
-	exit $rc
+if [ $rc -eq 1 ]; then
+        grep "\(error\):" $tmpfile_e
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
+        exit $rc
 fi
 
 git checkout -q HEAD~
@@ -44,13 +43,13 @@ git checkout -q HEAD~
 echo "Building the tree before the patch"
 
 tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
-	--environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
-	--environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
-	-o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
-	-K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
-	CROSS_COMPILE=riscv64-linux- \
-	config default \
-	> $tmpfile_o
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_o 2>/dev/null
 
 incumbent=$(grep -c "\(warning\|error\):" $tmpfile_o)
 
@@ -59,49 +58,48 @@ git checkout -q $HEAD
 echo "Building the tree with the patch"
 
 tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
-	--environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
-	--environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
-	-o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
-	-K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
-	CROSS_COMPILE=riscv64-linux- \
-	config default \
-	> $tmpfile_n || rc=1
+        --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
+        --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
+        -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
+        -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        CROSS_COMPILE=riscv64-linux- \
+        config default \
+        >$tmpfile_n 2>/dev/null || rc=1
 
-if [ $rc -eq 1 ]
-then
-	grep "\(warning\|error\):" $tmpfile_n >&2
-	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
-	exit $rc
+if [ $rc -eq 1 ]; then
+        grep "\(warning\|error\):" $tmpfile_n
+        rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+        exit $rc
 fi
 
 current=$(grep -c "\(warning\|error\):" $tmpfile_n)
 
 if [ $current -gt $incumbent ]; then
-  echo "New errors added:" 1>&2
+        echo "New errors added:"
 
-  tmpfile_errors_before=$(mktemp)
-  tmpfile_errors_now=$(mktemp)
-  grep "\(warning\|error\):" $tmpfile_o | sort | uniq -c > $tmpfile_errors_before
-  grep "\(warning\|error\):" $tmpfile_n | sort | uniq -c > $tmpfile_errors_now
+        tmpfile_errors_before=$(mktemp)
+        tmpfile_errors_now=$(mktemp)
+        grep "\(warning\|error\):" $tmpfile_o | sort | uniq -c > $tmpfile_errors_before
+        grep "\(warning\|error\):" $tmpfile_n | sort | uniq -c > $tmpfile_errors_now
 
-  diff -U 0 $tmpfile_errors_before $tmpfile_errors_now 1>&2
+        diff -U 0 $tmpfile_errors_before $tmpfile_errors_now
 
-  rm $tmpfile_errors_before $tmpfile_errors_now
+        rm $tmpfile_errors_before $tmpfile_errors_now
 
-  echo "Per-file breakdown" 1>&2
-  tmpfile_fo=$(mktemp)
-  tmpfile_fn=$(mktemp)
+        echo "Per-file breakdown"
+        tmpfile_fo=$(mktemp)
+        tmpfile_fn=$(mktemp)
 
-  grep "\(warning\|error\):" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fo
-  grep "\(warning\|error\):" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fn
+        grep "\(warning\|error\):" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fo
+        grep "\(warning\|error\):" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          > $tmpfile_fn
 
-  diff -U 0 $tmpfile_fo $tmpfile_fn 1>&2
-  rm $tmpfile_fo $tmpfile_fn
-  echo "pre: $incumbent post: $current"
+        diff -U 0 $tmpfile_fo $tmpfile_fn
+        rm $tmpfile_fo $tmpfile_fn
+        echo "pre: $incumbent post: $current"
 
-  rc=1
+        rc=1
 fi
 
 rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e

--- a/.github/scripts/patches/build_rv64_nommu_k210_defconfig.sh
+++ b/.github/scripts/patches/build_rv64_nommu_k210_defconfig.sh
@@ -12,10 +12,10 @@ tuxmake --wrapper ccache --target-arch riscv --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir --toolchain gcc -z none -k nommu_k210_defconfig \
         CROSS_COMPILE=riscv64-linux- \
-        > $tmpfile || rc=1
+        >$tmpfile 2>/dev/null || rc=1
 
 if [ $rc -ne 0 ]; then
-  grep "\(warning\|error\):" $tmpfile >&2
+        grep "\(warning\|error\):" $tmpfile
 fi
 
 rm -rf $tmpdir $tmpfile

--- a/.github/scripts/patches/build_rv64_nommu_virt_defconfig.sh
+++ b/.github/scripts/patches/build_rv64_nommu_virt_defconfig.sh
@@ -12,10 +12,10 @@ tuxmake --wrapper ccache --target-arch riscv --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir --toolchain gcc -z none -k nommu_virt_defconfig \
         CROSS_COMPILE=riscv64-linux- \
-        > $tmpfile || rc=1
+        >$tmpfile 2>/dev/null || rc=1
 
 if [ $rc -ne 0 ]; then
-  grep "\(warning\|error\):" $tmpfile >&2
+        grep "\(warning\|error\):" $tmpfile
 fi
 
 rm -rf $tmpdir $tmpfile

--- a/.github/scripts/patches/checkpatch.sh
+++ b/.github/scripts/patches/checkpatch.sh
@@ -22,9 +22,9 @@ ret=$?
 [ $ret -ne 0 ] && grep -P 'total: 0 errors, \d+ warnings, \d+ checks' $tmpfile && ret=250
 
 if [ $ret -ne 0 ]; then
-  grep '\(WARNING\|ERROR\|CHECK\): ' $tmpfile | LC_COLLATE=C sort -u
+        grep '\(WARNING\|ERROR\|CHECK\): ' $tmpfile | LC_COLLATE=C sort -u
 else
-  grep 'total: ' $tmpfile | LC_COLLATE=C sort -u
+        grep 'total: ' $tmpfile | LC_COLLATE=C sort -u
 fi
 
 rm $tmpfile

--- a/.github/scripts/patches/dtb_warn_rv64.sh
+++ b/.github/scripts/patches/dtb_warn_rv64.sh
@@ -25,11 +25,11 @@ git checkout -q HEAD~
 echo "Building the tree before the patch"
 
 make -C . O=$tmpdir_o ARCH=riscv CROSS_COMPILE=riscv64-linux- \
-	defconfig
+        defconfig
 
 make -C . O=$tmpdir_o ARCH=riscv CROSS_COMPILE=riscv64-linux- \
-	dtbs_check W=1 -j$(nproc) \
-	2> >(tee $tmpfile_o >&2)
+        dtbs_check W=1 -j$(nproc) \
+        2> >(tee $tmpfile_o)
 
 incumbent=$(cat $tmpfile_o | grep -v "From schema" | wc -l)
 
@@ -38,22 +38,22 @@ echo "Building the tree with the patch"
 git checkout -q $HEAD
 
 make -C . O=$tmpdir_n ARCH=riscv CROSS_COMPILE=riscv64-linux- \
-	defconfig
+        defconfig
 
 make -C . O=$tmpdir_n ARCH=riscv CROSS_COMPILE=riscv64-linux- \
-	dtbs_check W=1 -j$(nproc) \
-	2> >(tee $tmpfile_n >&2) || rc=1
+        dtbs_check W=1 -j$(nproc) \
+        2> >(tee $tmpfile_n) || rc=1
 
 current=$(cat $tmpfile_n | grep -v "From schema" | wc -l)
 
 if [ $current -gt $incumbent ]; then
-  echo "Errors and warnings before: $incumbent this patch: $current"
-  echo "New errors added" 1>&2
-  sed -i 's|^.*arch|arch|g' $tmpfile_o
-  sed -i 's|^.*arch|arch|g' $tmpfile_n
-  diff -U 0 $tmpfile_o $tmpfile_n 1>&2
+        echo "Errors and warnings before: $incumbent this patch: $current"
+        echo "New errors added"
+        sed -i 's|^.*arch|arch|g' $tmpfile_o
+        sed -i 's|^.*arch|arch|g' $tmpfile_n
+        diff -U 0 $tmpfile_o $tmpfile_n
 
-  rc=1
+        rc=1
 fi
 
 rm -rf $tmpdir_o $tmpdir_n $tmpfile_o $tmpfile_n

--- a/.github/scripts/patches/header_inline.sh
+++ b/.github/scripts/patches/header_inline.sh
@@ -9,11 +9,11 @@ inlines=$(
        )
 
 if [ -z "$inlines" ]; then
-  exit 0
-else
-  msg="Detected static functions without inline keyword in header files:"
-  echo -e "$msg\n$inlines" 1>&2
-  count=$( (echo "---"; echo "$inlines") | grep '^---$' | wc -l)
-  echo "$msg $count"
-  exit 1
+        exit 0
 fi
+
+msg="Detected static functions without inline keyword in header files:"
+echo -e "$msg\n$inlines"
+count=$( (echo "---"; echo "$inlines") | grep '^---$' | wc -l)
+echo "$msg $count"
+exit 1

--- a/.github/scripts/patches/kdoc.sh
+++ b/.github/scripts/patches/kdoc.sh
@@ -14,35 +14,35 @@ HEAD=$(git rev-parse HEAD)
 
 echo "Checking the tree before the patch"
 git checkout -q HEAD~
-./scripts/kernel-doc -none $files 2> >(tee $tmpfile_o >&2)
+./scripts/kernel-doc -none $files 2> >(tee $tmpfile_o)
 
 incumbent=$(grep -v 'Error: Cannot open file ' $tmpfile_o | wc -l)
 
 echo "Checking the tree with the patch"
 
 git checkout -q $HEAD
-./scripts/kernel-doc -none $files 2> >(tee $tmpfile_n >&2)
+./scripts/kernel-doc -none $files 2> >(tee $tmpfile_n)
 
 current=$(grep -v 'Error: Cannot open file ' $tmpfile_n | wc -l)
 
 
 if [ $current -gt $incumbent ]; then
-  echo "Errors and warnings before: $incumbent this patch: $current"
-  echo "New warnings added" 1>&2
-  diff $tmpfile_o $tmpfile_n 1>&2
+        echo "Errors and warnings before: $incumbent this patch: $current"
+        echo "New warnings added"
+        diff $tmpfile_o $tmpfile_n
 
-  echo "Per-file breakdown" 1>&2
-  tmpfile_fo=$(mktemp)
-  tmpfile_fn=$(mktemp)
+        echo "Per-file breakdown"
+        tmpfile_fo=$(mktemp)
+        tmpfile_fn=$(mktemp)
 
-  grep -i "\(warn\|error\)" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fo
-  grep -i "\(warn\|error\)" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fn
+        grep -i "\(warn\|error\)" $tmpfile_o | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          >$tmpfile_fo
+        grep -i "\(warn\|error\)" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
+          >$tmpfile_fn
 
-  diff $tmpfile_fo $tmpfile_fn 1>&2
-  rm $tmpfile_fo $tmpfile_fn
-  rc=1
+        diff $tmpfile_fo $tmpfile_fn
+        rm $tmpfile_fo $tmpfile_fn
+        rc=1
 fi
 
 rm $tmpfile_o $tmpfile_n

--- a/.github/scripts/patches/module_param.sh
+++ b/.github/scripts/patches/module_param.sh
@@ -10,12 +10,12 @@ old_params=$(git show | grep -ic '^\-.*module_param')
 echo "Was $old_params now: $new_params"
 
 if [ -z "$params" ]; then
-  exit 0
-else
-  echo -e "Detected module_param\n$params" 1>&2
-  if [ $new_params -eq $old_params ]; then
-    exit 250
-  else
-    exit 1
-  fi
+        exit 0
 fi
+
+echo -e "Detected module_param\n$params"
+if [ $new_params -eq $old_params ]; then
+        exit 250
+fi
+
+exit 1

--- a/.github/scripts/patches/verify_fixes.sh
+++ b/.github/scripts/patches/verify_fixes.sh
@@ -187,7 +187,7 @@ verify_fixes()
 				commit_msg=''
 				# Make sure we don't accidentally miss anything.
 				if [ $error -eq 0 ]; then
-					echo 'Whoops! $error out of sync with $msg' >&2
+					echo 'Whoops! $error out of sync with $msg'
 					error=1
 				fi
 			fi

--- a/.github/scripts/patches/verify_signedoff.sh
+++ b/.github/scripts/patches/verify_signedoff.sh
@@ -54,8 +54,8 @@ verify_signedoff()
 
 		if "$am" || "$cm"; then
 			printf "Commit %s\n" "$(git show -s --abbrev-commit --abbrev=12 --pretty=format:"%h (\"%s\")%n" "${c}")"
-			"$am" && printf "\tauthor Signed-off-by missing\n" # ::error::
-			"$cm" && printf "\tcommitter Signed-off-by missing\n" # ::error::
+			"$am" && printf "\tauthor Signed-off-by missing\n"
+			"$cm" && printf "\tcommitter Signed-off-by missing\n"
 			printf "\tauthor email:    %s\n" "$ae"
 			printf "\tcommitter email: %s\n"  "$ce"
 			readarray -t s <<< "${sob}"


### PR DESCRIPTION
Since the adoption of GNU parallel, the logging has been a bit off. This is due to the fact that parallel group output by stdout followed by stderr, and does not interleave it.

Remove all output to stdout, for log clarity. Also, silence a bunch of noise from tuxmake which users do not care about.

Finally, cleaned up a bunch of whitespace while walking the file. Diff with "git diff -w". ;-)