### PR TITLE
Bump timeout from 360m to 35d

### DIFF
--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -13,6 +13,7 @@ on: pull_request
 jobs:
   build-patches:
     runs-on: 'self-hosted'
+    timeout-minutes: 50400 # 35 days
     container:
       image: ghcr.io/linux-riscv/pw-builder:latest
       volumes:


### PR DESCRIPTION
Large series cannot complete in 6h. Bump to the maximum.