### PR TITLE
Disable DRM's "special" WERROR config

### DIFF
--- a/.github/scripts/patches/tests/build_rv64_clang_allmodconfig.sh
+++ b/.github/scripts/patches/tests/build_rv64_clang_allmodconfig.sh
@@ -28,6 +28,7 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
         -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y -K CONFIG_SAMPLES=n W=1 \
+        -K CONFIG_DRM_WERROR=n \
         CROSS_COMPILE=riscv64-linux- \
         config default \
         >$tmpfile_e 2>/dev/null || rc=1
@@ -49,6 +50,7 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
         -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
+        -K CONFIG_DRM_WERROR=n \
         CROSS_COMPILE=riscv64-linux- \
         config default \
         >$tmpfile_o 2>/dev/null
@@ -64,6 +66,7 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir_o -b $tmpdir_b --toolchain llvm -z none --kconfig allmodconfig \
         -K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
+        -K CONFIG_DRM_WERROR=n \
         CROSS_COMPILE=riscv64-linux- \
         config default \
         >$tmpfile_n 2>/dev/null || rc=1

--- a/.github/scripts/patches/tests/build_rv64_gcc_allmodconfig.sh
+++ b/.github/scripts/patches/tests/build_rv64_gcc_allmodconfig.sh
@@ -28,6 +28,7 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
         -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        -K CONFIG_DRM_WERROR=n \
         CROSS_COMPILE=riscv64-linux- \
         config default \
         >$tmpfile_e 2>/dev/null || rc=1
@@ -47,6 +48,7 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
         -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        -K CONFIG_DRM_WERROR=n \
         CROSS_COMPILE=riscv64-linux- \
         config default \
         >$tmpfile_o 2>/dev/null
@@ -62,6 +64,7 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir_o -b $tmpdir_b --toolchain gcc -z none --kconfig allmodconfig \
         -K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
+        -K CONFIG_DRM_WERROR=n \
         CROSS_COMPILE=riscv64-linux- \
         config default \
         >$tmpfile_n 2>/dev/null || rc=1

--- a/.github/scripts/series/build_kernel.sh
+++ b/.github/scripts/series/build_kernel.sh
@@ -47,6 +47,7 @@ if [[ $config == "allmodconfig" || $config == "randconfig" ]]; then
     make_wrap KCONFIG_ALLCONFIG=$lnxroot/arch/riscv/configs/${xlen//rv/}-bit.config $config
     $lnxroot/scripts/kconfig/merge_config.sh -m -O $output $output/.config \
                                              <(echo "CONFIG_WERROR=n") \
+                                             <(echo "CONFIG_DRM_WERROR=n") \
                                              <(echo "CONFIG_GCC_PLUGINS=n")
 elif [[ $config == "kselftest" ]]; then
     make_wrap defconfig


### PR DESCRIPTION
We want to see errors as warnings where possible so that the build actually completes.