### PR TITLE
Consider warnings as errors

### DIFF
--- a/.github/scripts/series/kernel_builder.sh
+++ b/.github/scripts/series/kernel_builder.sh
@@ -20,7 +20,13 @@ rc=0
 log="build_kernel___${n}.log"
 \time --quiet -o $tm -f "took %es" \
       $d/build_kernel.sh "${xlen}" "${config}" "${fragment}" "${toolchain}" &> "${logs}/${log}" || rc=$?
-if (( $rc )); then
+
+if grep -a ": warning:" "${logs}/${log}" | grep -v "the frame size"; then
+    # TODO Can't get rid of LLVM "warning: performing pointer arithmetic on a null pointer has undefined behavior [-Wnull-pointer-arithmetic]"
+    if [[ ! "${log}" =~ "nommu" ]]; then
+        echo "::error::FAIL WARNINGS kernel ${n} \"${log}\" $(cat $tm)"
+    fi
+elif (( $rc )); then
     echo "::error::FAIL Build kernel ${n} \"${log}\" $(cat $tm)"
 else
     echo "::notice::OK Build kernel ${n} $(cat $tm)"


### PR DESCRIPTION
Except for the frame size errors and nommu for which I can't get rid of:

warning: performing pointer arithmetic on a null pointer has undefined behavior